### PR TITLE
Feature/12

### DIFF
--- a/src/main/java/streamingsettlement/batch/job/StatisticsJobConfig.java
+++ b/src/main/java/streamingsettlement/batch/job/StatisticsJobConfig.java
@@ -4,33 +4,19 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
-import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.configuration.annotation.JobScope;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
-import org.springframework.batch.item.ItemProcessor;
-import org.springframework.batch.item.data.RepositoryItemReader;
-import org.springframework.batch.item.data.RepositoryItemWriter;
-import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
-import org.springframework.batch.item.data.builder.RepositoryItemWriterBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.domain.Sort;
 import org.springframework.transaction.PlatformTransactionManager;
 import streamingsettlement.adjustment.domain.entity.StreamingSettlementHistory;
-import streamingsettlement.adjustment.repository.jpa.StreamingSettlementHistoryJpaRepository;
 import streamingsettlement.batch.listener.JobTimeListener;
-import streamingsettlement.streaming.domain.entity.Streaming;
-import streamingsettlement.streaming.repository.jpa.PlayHistoryJpaRepository;
-import streamingsettlement.streaming.repository.jpa.StreamingJpaRepository;
-
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Map;
+import streamingsettlement.batch.reader.DailySettlementDTO;
+import streamingsettlement.batch.reader.StreamingStepV3;
 
 @Slf4j
 @Configuration
@@ -43,101 +29,29 @@ public class StatisticsJobConfig {
     private final PlatformTransactionManager transactionManager;
     private final JobTimeListener jobTimeListener;
 
-    private final StreamingJpaRepository streamingRepository;
-    private final StreamingSettlementHistoryJpaRepository streamingSettlementHistoryJpaRepository;
-    private final PlayHistoryJpaRepository playHistoryJpaRepository;
+    private final StreamingStepV3 streamingStep;
 
     @Bean
-    public Job dailySettlementJob() {
+    public Job dailySettlementJob(Step streamingSettlementStep) {
         return new JobBuilder("dailySettlementJob", jobRepository)
                 .incrementer(new RunIdIncrementer())
                 .listener(jobTimeListener)
-                .start(streamingSettlementStep())
+                .start(streamingSettlementStep)
                 .build();
     }
 
     @Bean
-    public Step streamingSettlementStep() {
-        return new StepBuilder("streamingSettlementStep", jobRepository)
-                .<Streaming, StreamingSettlementHistory>chunk(CHUNK_SIZE, transactionManager)
-                .reader(streamingReader())
-                .processor(streamingSettlementProcessor(null))
-                .writer(streamingSettlementWriter())
-                .build();
-    }
-
-    @Bean
-    public RepositoryItemReader<Streaming> streamingReader() {
-        log.info("streamingReader start");
-        return new RepositoryItemReaderBuilder<Streaming>()
-                .name("streamingReader")
-                .repository(streamingRepository)
-                .methodName("findAll")
-                .pageSize(CHUNK_SIZE)
-                .sorts(Map.of("id", Sort.Direction.ASC))
-                .build();
-    }
-
-    @Bean
-    @StepScope
-    public ItemProcessor<Streaming, StreamingSettlementHistory> streamingSettlementProcessor(
-            @Value("#{jobParameters[targetDate]}") String date
+    @JobScope
+    public Step streamingSettlementStep(
+            @Value("#{jobParameters[targetDate]}") String targetDate
     ) {
-        log.info("streamingSettlementProcessor start");
-
-        LocalDate targetDate = LocalDate.parse(date);
-        LocalDateTime startOfDay = targetDate.atStartOfDay();
-        LocalDateTime endOfDay = targetDate.atStartOfDay().plusDays(1);
-
-        return streaming -> {
-            long dailyViews = playHistoryJpaRepository.countByStreamingIdAndCreatedAtBetween(
-                    streaming.getId(),
-                    startOfDay,
-                    endOfDay
-            );
-
-            if (dailyViews == 0) {
-                System.out.println("dailyViews == 0");
-                return null;
-            }
-
-            BigDecimal unitPrice = calculateStreamingUnitPrice(dailyViews);
-            BigDecimal settlementAmount = unitPrice.multiply(BigDecimal.valueOf(dailyViews))
-                    .setScale(0, RoundingMode.DOWN);
-
-            System.out.println("Streaming ID: " + streaming.getId() + " 정산 처리 완료, 금액: " + settlementAmount);
-
-            return StreamingSettlementHistory.builder()
-                    .streamingId(streaming.getId())
-                    .settlementView(dailyViews)
-                    .streamingAmount(settlementAmount)
-                    .settlementAt(LocalDateTime.now())
-                    .build();
-        };
-    }
-
-    @Bean
-    public RepositoryItemWriter<StreamingSettlementHistory> streamingSettlementWriter() {
-        log.info("streamingSettlementWriter start");
-
-        return new RepositoryItemWriterBuilder<StreamingSettlementHistory>()
-                .repository(streamingSettlementHistoryJpaRepository)
-                .methodName("save")
+        return new StepBuilder("streamingSettlementStep", jobRepository)
+                .<DailySettlementDTO, StreamingSettlementHistory>chunk(CHUNK_SIZE, transactionManager)
+                .reader(streamingStep.streamingReader(targetDate))
+                .processor(streamingStep.streamingProcessor())
+                .writer(streamingStep.streamingWriter())
                 .build();
-    }
-
-    private BigDecimal calculateStreamingUnitPrice(long views) {
-        if (views >= 1_000_000) return BigDecimal.valueOf(1.5);
-        if (views >= 500_000) return BigDecimal.valueOf(1.3);
-        if (views >= 100_000) return BigDecimal.valueOf(1.1);
-        return BigDecimal.valueOf(1.0);
-    }
-
-    private BigDecimal calculateAdUnitPrice(long views) {
-        if (views >= 1_000_000) return BigDecimal.valueOf(20);
-        if (views >= 500_000) return BigDecimal.valueOf(15);
-        if (views >= 100_000) return BigDecimal.valueOf(12);
-        return BigDecimal.valueOf(10);
     }
 }
+
 

--- a/src/main/java/streamingsettlement/batch/reader/DailySettlementDTO.java
+++ b/src/main/java/streamingsettlement/batch/reader/DailySettlementDTO.java
@@ -1,0 +1,11 @@
+package streamingsettlement.batch.reader;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DailySettlementDTO {
+    private final Long streamingId;
+    private final Long viewCount;
+}

--- a/src/main/java/streamingsettlement/batch/reader/StreamingStepV1.java
+++ b/src/main/java/streamingsettlement/batch/reader/StreamingStepV1.java
@@ -1,0 +1,112 @@
+package streamingsettlement.batch.reader;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.RepositoryItemWriter;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.batch.item.data.builder.RepositoryItemWriterBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+import streamingsettlement.adjustment.domain.entity.StreamingSettlementHistory;
+import streamingsettlement.adjustment.repository.jpa.StreamingSettlementHistoryJpaRepository;
+import streamingsettlement.streaming.domain.entity.Streaming;
+import streamingsettlement.streaming.repository.jpa.PlayHistoryJpaRepository;
+import streamingsettlement.streaming.repository.jpa.StreamingJpaRepository;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+/**
+ * RepositoryItemReader 활용 배치
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StreamingStepV1 {
+
+    private static final int CHUNK_SIZE = 5000;
+
+    private final StreamingJpaRepository streamingRepository;
+    private final StreamingSettlementHistoryJpaRepository streamingSettlementHistoryJpaRepository;
+    private final PlayHistoryJpaRepository playHistoryJpaRepository;
+
+    @Bean
+    public RepositoryItemReader<Streaming> streamingReader() {
+        log.info("streamingReader start");
+        return new RepositoryItemReaderBuilder<Streaming>()
+                .name("streamingReader")
+                .repository(streamingRepository)
+                .methodName("findAll")
+                .pageSize(CHUNK_SIZE)
+                .sorts(Map.of("id", Sort.Direction.ASC))
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public ItemProcessor<Streaming, StreamingSettlementHistory> streamingSettlementProcessor(
+            @Value("#{jobParameters[targetDate]}") String date
+    ) {
+        log.info("streamingSettlementProcessor start");
+
+        LocalDate targetDate = LocalDate.parse(date);
+        LocalDateTime startOfDay = targetDate.atStartOfDay();
+        LocalDateTime endOfDay = targetDate.atStartOfDay().plusDays(1);
+
+        return streaming -> {
+            long dailyViews = playHistoryJpaRepository.countByStreamingIdAndCreatedAtBetween(
+                    streaming.getId(),
+                    startOfDay,
+                    endOfDay
+            );
+
+            if (dailyViews == 0) {
+                System.out.println("dailyViews == 0");
+                return null;
+            }
+
+            BigDecimal unitPrice = calculateStreamingUnitPrice(dailyViews);
+            BigDecimal settlementAmount = unitPrice.multiply(BigDecimal.valueOf(dailyViews))
+                    .setScale(0, RoundingMode.DOWN);
+
+            return StreamingSettlementHistory.builder()
+                    .streamingId(streaming.getId())
+                    .settlementView(dailyViews)
+                    .streamingAmount(settlementAmount)
+                    .settlementAt(LocalDateTime.now())
+                    .build();
+        };
+    }
+
+    @Bean
+    public RepositoryItemWriter<StreamingSettlementHistory> streamingSettlementWriter() {
+        log.info("streamingSettlementWriter start");
+
+        return new RepositoryItemWriterBuilder<StreamingSettlementHistory>()
+                .repository(streamingSettlementHistoryJpaRepository)
+                .methodName("save")
+                .build();
+    }
+
+    private BigDecimal calculateStreamingUnitPrice(long views) {
+        if (views >= 1_000_000) return BigDecimal.valueOf(1.5);
+        if (views >= 500_000) return BigDecimal.valueOf(1.3);
+        if (views >= 100_000) return BigDecimal.valueOf(1.1);
+        return BigDecimal.valueOf(1.0);
+    }
+
+    private BigDecimal calculateAdUnitPrice(long views) {
+        if (views >= 1_000_000) return BigDecimal.valueOf(20);
+        if (views >= 500_000) return BigDecimal.valueOf(15);
+        if (views >= 100_000) return BigDecimal.valueOf(12);
+        return BigDecimal.valueOf(10);
+    }
+}

--- a/src/main/java/streamingsettlement/batch/reader/StreamingStepV2.java
+++ b/src/main/java/streamingsettlement/batch/reader/StreamingStepV2.java
@@ -1,0 +1,100 @@
+package streamingsettlement.batch.reader;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.RepositoryItemWriter;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.batch.item.data.builder.RepositoryItemWriterBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+import streamingsettlement.adjustment.domain.entity.StreamingSettlementHistory;
+import streamingsettlement.adjustment.repository.jpa.StreamingSettlementHistoryJpaRepository;
+import streamingsettlement.streaming.repository.jpa.PlayHistoryJpaRepository;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * Reader에서 집계 쿼리로 진행
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StreamingStepV2 {
+
+    private static final int CHUNK_SIZE = 5000;
+
+    private final StreamingSettlementHistoryJpaRepository streamingSettlementHistoryJpaRepository;
+    private final PlayHistoryJpaRepository playHistoryJpaRepository;
+
+
+    @Bean
+    @StepScope
+    public RepositoryItemReader<DailySettlementDTO> streamingReader(
+            @Value("#{jobParameters[targetDate]}") String date
+    ) {
+        log.info("streamingReader start");
+        LocalDate targetDate = LocalDate.parse(date);
+        LocalDateTime startOfDay = targetDate.atStartOfDay();
+        LocalDateTime endOfDay = targetDate.atStartOfDay().plusDays(1);
+
+        return new RepositoryItemReaderBuilder<DailySettlementDTO>()
+                .name("streamingReader")
+                .repository(playHistoryJpaRepository)
+                .methodName("findDailySettlements")
+                .arguments(Arrays.asList(startOfDay, endOfDay))
+                .pageSize(CHUNK_SIZE)
+                .sorts(Map.of("streamingId", Sort.Direction.ASC))
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<DailySettlementDTO, StreamingSettlementHistory> streamingProcessor() {
+
+        return dto -> {
+            log.info("Processing DailySettlementDTO: {} ,{}", dto.getStreamingId(),dto.getViewCount());
+
+            BigDecimal unitPrice = calculateStreamingUnitPrice(dto.getViewCount());
+            BigDecimal settlementAmount = unitPrice.multiply(BigDecimal.valueOf(dto.getViewCount()))
+                    .setScale(0, RoundingMode.DOWN);
+
+            return StreamingSettlementHistory.builder()
+                    .streamingId(dto.getStreamingId())
+                    .settlementView(dto.getViewCount())
+                    .streamingAmount(settlementAmount)
+                    .settlementAt(LocalDateTime.now())
+                    .build();
+        };
+    }
+
+    @Bean
+    public RepositoryItemWriter<StreamingSettlementHistory> streamingWriter() {
+        log.info("streamingWriter start");
+        return new RepositoryItemWriterBuilder<StreamingSettlementHistory>()
+                .repository(streamingSettlementHistoryJpaRepository)
+                .methodName("save")
+                .build();
+    }
+    private BigDecimal calculateStreamingUnitPrice(long views) {
+        if (views >= 1_000_000) return BigDecimal.valueOf(1.5);
+        if (views >= 500_000) return BigDecimal.valueOf(1.3);
+        if (views >= 100_000) return BigDecimal.valueOf(1.1);
+        return BigDecimal.valueOf(1.0);
+    }
+
+    private BigDecimal calculateAdUnitPrice(long views) {
+        if (views >= 1_000_000) return BigDecimal.valueOf(20);
+        if (views >= 500_000) return BigDecimal.valueOf(15);
+        if (views >= 100_000) return BigDecimal.valueOf(12);
+        return BigDecimal.valueOf(10);
+    }
+}

--- a/src/main/java/streamingsettlement/batch/reader/StreamingStepV3.java
+++ b/src/main/java/streamingsettlement/batch/reader/StreamingStepV3.java
@@ -1,0 +1,112 @@
+package streamingsettlement.batch.reader;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+import streamingsettlement.adjustment.domain.entity.StreamingSettlementHistory;
+import streamingsettlement.streaming.repository.jpa.PlayHistoryJpaRepository;
+
+import javax.sql.DataSource;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * jpa save -> jdbc batch insert
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StreamingStepV3 {
+
+    private static final int CHUNK_SIZE = 5000;
+
+    private final DataSource dataSource;
+    private final PlayHistoryJpaRepository playHistoryJpaRepository;
+
+
+    @Bean
+    @StepScope
+    public RepositoryItemReader<DailySettlementDTO> streamingReader(
+            @Value("#{jobParameters[targetDate]}") String date
+    ) {
+        log.info("streamingReader start");
+        LocalDate targetDate = LocalDate.parse(date);
+        LocalDateTime startOfDay = targetDate.atStartOfDay();
+        LocalDateTime endOfDay = targetDate.atStartOfDay().plusDays(1);
+
+        return new RepositoryItemReaderBuilder<DailySettlementDTO>()
+                .name("streamingReader")
+                .repository(playHistoryJpaRepository)
+                .methodName("findDailySettlements")
+                .arguments(Arrays.asList(startOfDay, endOfDay))
+                .pageSize(CHUNK_SIZE)
+                .sorts(Map.of("streamingId", Sort.Direction.ASC))
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<DailySettlementDTO, StreamingSettlementHistory> streamingProcessor() {
+
+        return dto -> {
+            log.info("Processing DailySettlementDTO: {} ,{}", dto.getStreamingId(), dto.getViewCount());
+
+            BigDecimal unitPrice = calculateStreamingUnitPrice(dto.getViewCount());
+            BigDecimal settlementAmount = unitPrice.multiply(BigDecimal.valueOf(dto.getViewCount()))
+                    .setScale(0, RoundingMode.DOWN);
+
+            return StreamingSettlementHistory.builder()
+                    .streamingId(dto.getStreamingId())
+                    .settlementView(dto.getViewCount())
+                    .streamingAmount(settlementAmount)
+                    .settlementAt(LocalDateTime.now())
+                    .build();
+        };
+    }
+
+    @Bean
+    public JdbcBatchItemWriter<StreamingSettlementHistory> streamingWriter() {
+        log.info("streamingWriter start");
+        return new JdbcBatchItemWriterBuilder<StreamingSettlementHistory>()
+                .dataSource(dataSource)
+                .sql("""
+                        INSERT INTO streaming_settlement_history 
+                        (streaming_id, settlement_view, streaming_amount, settlement_at)
+                        VALUES (?, ?, ?, ?)
+                        """)
+                .itemPreparedStatementSetter((item, ps) -> {
+                    ps.setLong(1, item.getStreamingId());
+                    ps.setLong(2, item.getSettlementView());
+                    ps.setBigDecimal(3, item.getStreamingAmount());
+                    ps.setObject(4, item.getSettlementAt());
+                })
+                .assertUpdates(false)
+                .build();
+    }
+
+    private BigDecimal calculateStreamingUnitPrice(long views) {
+        if (views >= 1_000_000) return BigDecimal.valueOf(1.5);
+        if (views >= 500_000) return BigDecimal.valueOf(1.3);
+        if (views >= 100_000) return BigDecimal.valueOf(1.1);
+        return BigDecimal.valueOf(1.0);
+    }
+
+    private BigDecimal calculateAdUnitPrice(long views) {
+        if (views >= 1_000_000) return BigDecimal.valueOf(20);
+        if (views >= 500_000) return BigDecimal.valueOf(15);
+        if (views >= 100_000) return BigDecimal.valueOf(12);
+        return BigDecimal.valueOf(10);
+    }
+}

--- a/src/main/java/streamingsettlement/streaming/repository/jpa/PlayHistoryJpaRepository.java
+++ b/src/main/java/streamingsettlement/streaming/repository/jpa/PlayHistoryJpaRepository.java
@@ -1,12 +1,17 @@
 package streamingsettlement.streaming.repository.jpa;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import streamingsettlement.adjustment.domain.entity.StreamingSettlementHistory;
+import streamingsettlement.batch.reader.DailySettlementDTO;
 import streamingsettlement.streaming.domain.entity.PlayHistory;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-public interface PlayHistoryJpaRepository extends JpaRepository<PlayHistory,Long> {
+public interface PlayHistoryJpaRepository extends JpaRepository<PlayHistory, Long> {
 
     Optional<PlayHistory> findFirstBySourceIpAndStreamingIdOrderByCreatedAtDesc(String sourceIp, Long streamingId);
 
@@ -15,4 +20,21 @@ public interface PlayHistoryJpaRepository extends JpaRepository<PlayHistory,Long
             LocalDateTime startDate,
             LocalDateTime endDate
     );
+
+    @Query("""
+            SELECT new streamingsettlement.batch.reader.DailySettlementDTO(
+                p.streamingId,
+                COUNT(p)
+            )
+            FROM PlayHistory p
+            WHERE p.createdAt BETWEEN :startDate AND :endDate
+            GROUP BY p.streamingId
+            HAVING COUNT(p) > 0
+            """)
+    Page<DailySettlementDTO> findDailySettlements(
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            Pageable pageable
+    );
 }
+


### PR DESCRIPTION
스트리밍 배치 정산 성능 개선
- 인덱스를 활용한 RepositoryItemReader 배치 (8101초)
- Reader에서 집계 쿼리 배치 (272초)
- jpa save ->  jdbc batch insert (196초)
- 병렬 처리 (95초)