### PR TITLE
[#18]feat: 멀티 스레딩을 통한 배치 병렬 처리

### DIFF
--- a/src/main/java/streamingsettlement/batch/job/StatisticsJobConfigV4.java
+++ b/src/main/java/streamingsettlement/batch/job/StatisticsJobConfigV4.java
@@ -1,0 +1,123 @@
+package streamingsettlement.batch.job;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.transaction.PlatformTransactionManager;
+import streamingsettlement.adjustment.domain.entity.AdSettlementHistory;
+import streamingsettlement.adjustment.domain.entity.DailyStatistic;
+import streamingsettlement.adjustment.domain.entity.StreamingSettlementHistory;
+import streamingsettlement.batch.listener.JobTimeListener;
+import streamingsettlement.batch.step.AdSettlementStepV2;
+import streamingsettlement.batch.step.StreamingSettlementStepV2;
+import streamingsettlement.batch.step.v3.AdViewAggregationStepV3;
+import streamingsettlement.batch.step.v3.RedisToDailyStatisticStepV3;
+import streamingsettlement.streaming.domain.entity.PlayHistory;
+import streamingsettlement.streaming.domain.entity.Streaming;
+
+/**
+ * 병렬 처리 : 멀티 스레드
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class StatisticsJobConfigV4 {
+
+    private static final int CHUNK_SIZE = 5000;
+    private static final int THREAD_COUNT = 5;
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final JobTimeListener jobTimeListener;
+
+    private final AdViewAggregationStepV3 adViewAggregationStep;
+    private final RedisToDailyStatisticStepV3 redisToDailyStatisticStep;
+    private final AdSettlementStepV2 adSettlementStep;
+    private final StreamingSettlementStepV2 streamingSettlementStep;
+
+    @Bean
+    public Job dailyStatisticsJob() {
+        return new JobBuilder("dailyStatisticsJob", jobRepository)
+                .listener(jobTimeListener)
+                .start(aggregateDataStep(null))
+                .next(processDataStep(null))
+                .next(adSettlementStep(null))
+                .next(dailyStatisticStep(null))
+                .build();
+    }
+
+    @Bean
+    @JobScope
+    public Step aggregateDataStep(
+            @Value("#{jobParameters[targetDate]}") String targetDate
+    ) {
+        return new StepBuilder("aggregateDataStep", jobRepository)
+                .<PlayHistory, PlayHistory>chunk(CHUNK_SIZE, transactionManager)
+                .reader(adViewAggregationStep.playHistoryReader(targetDate))
+                .writer(adViewAggregationStep.redisWriter(targetDate))
+                .taskExecutor(taskExecutor())
+                .build();
+    }
+
+    @Bean
+    @JobScope
+    public Step processDataStep(
+            @Value("#{jobParameters[targetDate]}") String targetDate
+    ) {
+        return new StepBuilder("processDataStep", jobRepository)
+                .<Streaming, DailyStatistic>chunk(CHUNK_SIZE, transactionManager)
+                .reader(redisToDailyStatisticStep.streamingReader())
+                .processor(redisToDailyStatisticStep.dailyStatisticProcessor(targetDate))
+                .writer(redisToDailyStatisticStep.dailyStatisticWriter())
+                .taskExecutor(taskExecutor())
+                .build();
+    }
+
+    @Bean
+    @JobScope
+    public Step adSettlementStep(
+            @Value("#{jobParameters[targetDate]}") String targetDate
+    ) {
+        return new StepBuilder("streamingSettlementStep", jobRepository)
+                .<DailyStatistic, AdSettlementHistory>chunk(CHUNK_SIZE, transactionManager)
+                .reader(adSettlementStep.adSettlementDailyStatisticReader(targetDate))
+                .processor(adSettlementStep.adSettlementProcessor())
+                .writer(adSettlementStep.adSettlementWriter())
+                .taskExecutor(taskExecutor())
+                .build();
+    }
+
+    @Bean
+    @JobScope
+    public Step dailyStatisticStep(
+            @Value("#{jobParameters[targetDate]}") String targetDate
+    ) {
+        return new StepBuilder("dailyStatisticStep", jobRepository)
+                .<DailyStatistic, StreamingSettlementHistory>chunk(CHUNK_SIZE, transactionManager)
+                .reader(streamingSettlementStep.streamingSettlementDailyStatisticReader(targetDate))
+                .processor(streamingSettlementStep.streamingSettlementProcessor())
+                .writer(streamingSettlementStep.streamingSettlementWriter())
+                .taskExecutor(taskExecutor())
+                .build();
+    }
+
+    @Bean
+    public ThreadPoolTaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(THREAD_COUNT);
+        executor.setMaxPoolSize(THREAD_COUNT);
+        executor.setQueueCapacity(CHUNK_SIZE);
+        executor.setThreadNamePrefix("batch-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/streamingsettlement/batch/step/AdSettlementStepV2.java
+++ b/src/main/java/streamingsettlement/batch/step/AdSettlementStepV2.java
@@ -1,0 +1,124 @@
+package streamingsettlement.batch.step;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.JdbcCursorItemReader;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.batch.item.support.SynchronizedItemStreamReader;
+import org.springframework.batch.item.support.builder.SynchronizedItemStreamReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import streamingsettlement.adjustment.domain.entity.AdSettlementHistory;
+import streamingsettlement.adjustment.domain.entity.DailyStatistic;
+import streamingsettlement.adjustment.repository.jpa.AdSettlementHistoryJpaRepository;
+import streamingsettlement.batch.calculator.SettlementCalculator;
+
+import javax.sql.DataSource;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 병렬 처리 : 멀티 스레드
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AdSettlementStepV2 {
+
+    private final AdSettlementHistoryJpaRepository adSettlementHistoryJpaRepository;
+
+    private final DataSource dataSource;
+
+    @Bean
+    @StepScope
+    public SynchronizedItemStreamReader<DailyStatistic> adSettlementDailyStatisticReader(
+            @Value("#{jobParameters[targetDate]}") String date
+    ) {
+
+        LocalDate targetDate = LocalDate.parse(date);
+        LocalDateTime startDate = targetDate.atStartOfDay();
+        LocalDateTime endDate = targetDate.atStartOfDay().plusDays(1);
+
+        JdbcCursorItemReader<DailyStatistic> reader = new JdbcCursorItemReader<>();
+        reader.setDataSource(dataSource);
+        reader.setSql("""
+                SELECT *
+                FROM daily_statistic
+                WHERE statistic_date >= ? AND statistic_date < ?
+                ORDER BY id ASC
+                        """);
+        reader.setPreparedStatementSetter(ps -> {
+            ps.setTimestamp(1, Timestamp.valueOf(startDate));
+            ps.setTimestamp(2, Timestamp.valueOf(endDate));
+        });
+        reader.setRowMapper((rs, rowNum) ->
+                DailyStatistic.builder()
+                        .id(rs.getLong("id"))
+                        .streamingId(rs.getLong("streaming_id"))
+                        .streamingAmount(rs.getBigDecimal("streaming_amount"))
+                        .advertisementAmount(rs.getBigDecimal("advertisement_amount"))
+                        .streamingViews(rs.getLong("streaming_views"))
+                        .advertisementViews(rs.getLong("advertisement_views"))
+                        .playTime(rs.getLong("play_time"))
+                        .statisticDate(rs.getTimestamp("statistic_date").toLocalDateTime())
+                        .createdAt(rs.getTimestamp("created_at").toLocalDateTime())
+                        .build()
+        );
+        return new SynchronizedItemStreamReaderBuilder<DailyStatistic>()
+                .delegate(reader)
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<DailyStatistic, AdSettlementHistory> adSettlementProcessor() {
+        return dailyStatistic -> {
+
+            Long adView = dailyStatistic.getAdvertisementViews();
+            Long streamingView = dailyStatistic.getStreamingViews();
+
+            BigDecimal adUnitPrice = SettlementCalculator.calculateAdUnitPrice(streamingView);
+            BigDecimal adAmount = adUnitPrice.multiply(BigDecimal.valueOf(adView))
+                    .setScale(0, RoundingMode.DOWN);
+
+
+            log.info("광고 정산 처리 완료 - streamingId: {}, adViews: {}, adAmount: {}", dailyStatistic.getStreamingId(), adView, adAmount);
+            return AdSettlementHistory.builder()
+                    .streamingId(dailyStatistic.getStreamingId())
+                    .adViews(adView)
+                    .adAmount(adAmount)
+                    .settlementAt(LocalDateTime.now())
+                    .build();
+        };
+    }
+
+    @Bean
+    public JdbcBatchItemWriter<AdSettlementHistory> adSettlementWriter() {
+        log.info("streamingSettlementWriter start");
+
+        return new JdbcBatchItemWriterBuilder<AdSettlementHistory>()
+                .dataSource(dataSource)
+                .sql("""
+                INSERT INTO ad_settlement_history (
+                    streaming_id,
+                    ad_views,
+                    ad_amount,
+                    settlement_at
+                ) VALUES (?, ?, ?, ?)
+                """)
+                .itemPreparedStatementSetter((item, ps) -> {
+                    ps.setLong(1, item.getStreamingId());
+                    ps.setLong(2, item.getAdViews());
+                    ps.setBigDecimal(3, item.getAdAmount());
+                    ps.setTimestamp(4, Timestamp.valueOf(item.getSettlementAt()));
+                })
+                .assertUpdates(false)
+                .build();
+    }
+}

--- a/src/main/java/streamingsettlement/batch/step/StreamingSettlementStepV2.java
+++ b/src/main/java/streamingsettlement/batch/step/StreamingSettlementStepV2.java
@@ -1,0 +1,122 @@
+package streamingsettlement.batch.step;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.JdbcCursorItemReader;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.batch.item.support.SynchronizedItemStreamReader;
+import org.springframework.batch.item.support.builder.SynchronizedItemStreamReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import streamingsettlement.adjustment.domain.entity.DailyStatistic;
+import streamingsettlement.adjustment.domain.entity.StreamingSettlementHistory;
+import streamingsettlement.adjustment.repository.jpa.StreamingSettlementHistoryJpaRepository;
+import streamingsettlement.batch.calculator.SettlementCalculator;
+
+import javax.sql.DataSource;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 병렬 처리 : 멀티 스레드
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StreamingSettlementStepV2 {
+
+    private final DataSource dataSource;
+    private final StreamingSettlementHistoryJpaRepository streamingSettlementHistoryJpaRepository;
+
+    @Bean
+    @StepScope
+    public SynchronizedItemStreamReader<DailyStatistic> streamingSettlementDailyStatisticReader(
+            @Value("#{jobParameters[targetDate]}") String date
+    ) {
+
+        LocalDate targetDate = LocalDate.parse(date);
+        LocalDateTime startDate = targetDate.atStartOfDay();
+        LocalDateTime endDate = targetDate.atStartOfDay().plusDays(1);
+
+        JdbcCursorItemReader<DailyStatistic> reader = new JdbcCursorItemReader<>();
+        reader.setDataSource(dataSource);
+        reader.setSql("""
+                SELECT *
+                FROM daily_statistic
+                WHERE statistic_date >= ? AND statistic_date < ?
+                ORDER BY id ASC
+                        """);
+        reader.setPreparedStatementSetter(ps -> {
+            ps.setTimestamp(1, Timestamp.valueOf(startDate));
+            ps.setTimestamp(2, Timestamp.valueOf(endDate));
+        });
+        reader.setRowMapper((rs, rowNum) ->
+                DailyStatistic.builder()
+                        .id(rs.getLong("id"))
+                        .streamingId(rs.getLong("streaming_id"))
+                        .streamingAmount(rs.getBigDecimal("streaming_amount"))
+                        .advertisementAmount(rs.getBigDecimal("advertisement_amount"))
+                        .streamingViews(rs.getLong("streaming_views"))
+                        .advertisementViews(rs.getLong("advertisement_views"))
+                        .playTime(rs.getLong("play_time"))
+                        .statisticDate(rs.getTimestamp("statistic_date").toLocalDateTime())
+                        .createdAt(rs.getTimestamp("created_at").toLocalDateTime())
+                        .build()
+        );
+        return new SynchronizedItemStreamReaderBuilder<DailyStatistic>()
+                .delegate(reader)
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<DailyStatistic, StreamingSettlementHistory> streamingSettlementProcessor() {
+        return dailyStatistic -> {
+
+            Long streamingView = dailyStatistic.getStreamingViews();
+
+            BigDecimal streamingUnitPrice = SettlementCalculator.calculateStreamingUnitPrice(streamingView);
+            BigDecimal streamingAmount = streamingUnitPrice.multiply(BigDecimal.valueOf(streamingView))
+                    .setScale(0, RoundingMode.DOWN);
+
+            log.info("스트리밍 정산 처리 완료 - streamingId: {}, streamingView: {}, streamingAmount: {}", dailyStatistic.getStreamingId(), streamingView, streamingAmount);
+
+            return StreamingSettlementHistory.builder()
+                    .streamingId(dailyStatistic.getStreamingId())
+                    .streamingViews(streamingView)
+                    .streamingAmount(streamingAmount)
+                    .settlementAt(LocalDateTime.now())
+                    .build();
+        };
+    }
+
+    @Bean
+    public JdbcBatchItemWriter<StreamingSettlementHistory> streamingSettlementWriter() {
+        log.info("streamingSettlementWriter start");
+
+        return new JdbcBatchItemWriterBuilder<StreamingSettlementHistory>()
+                .dataSource(dataSource)
+                .sql("""
+                        INSERT INTO streaming_settlement_history (
+                            streaming_id,
+                            streaming_views,
+                            streaming_amount,
+                            settlement_at
+                        ) VALUES ( ?, ?, ?, ?)
+                        """)
+                .itemPreparedStatementSetter((item, ps) -> {
+                    ps.setLong(1, item.getStreamingId());
+                    ps.setLong(2, item.getStreamingViews());
+                    ps.setBigDecimal(3, item.getStreamingAmount());
+                    ps.setTimestamp(4, Timestamp.valueOf(item.getSettlementAt()));
+                })
+                .assertUpdates(false)
+                .build();
+    }
+}

--- a/src/main/java/streamingsettlement/batch/step/v3/AdViewAggregationStepV3.java
+++ b/src/main/java/streamingsettlement/batch/step/v3/AdViewAggregationStepV3.java
@@ -1,0 +1,118 @@
+package streamingsettlement.batch.step.v3;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JdbcCursorItemReader;
+import org.springframework.batch.item.support.SynchronizedItemStreamReader;
+import org.springframework.batch.item.support.builder.SynchronizedItemStreamReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import streamingsettlement.streaming.domain.entity.PlayHistory;
+
+import javax.sql.DataSource;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 병렬 처리 : 멀티 스레드
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AdViewAggregationStepV3 {
+
+    private static final int AD_INTERVAL_MINUTES = 420;
+
+    private final DataSource dataSource;
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String REDIS_KEY_PREFIX = "daily_stats:";
+
+    @Bean
+    @StepScope
+    public SynchronizedItemStreamReader<PlayHistory> playHistoryReader(
+            @Value("#{jobParameters[targetDate]}") String date
+    ) {
+        LocalDate targetDate = LocalDate.parse(date);
+        LocalDateTime startOfDay = targetDate.atStartOfDay();
+        LocalDateTime endOfDay = targetDate.plusDays(1).atStartOfDay().minusMinutes(1);
+
+        JdbcCursorItemReader<PlayHistory> reader = new JdbcCursorItemReader<>();
+        reader.setDataSource(dataSource);
+        reader.setSql("""
+                    SELECT *
+                    FROM play_history
+                    WHERE created_at BETWEEN ? AND ?
+                    ORDER BY id ASC
+                """);
+
+        reader.setPreparedStatementSetter(ps -> {
+            ps.setTimestamp(1, Timestamp.valueOf(startOfDay));
+            ps.setTimestamp(2, Timestamp.valueOf(endOfDay));
+        });
+
+        reader.setRowMapper((rs, rowNum) -> {
+            PlayHistory playHistory = new PlayHistory();
+            playHistory.setId(rs.getLong("id"));
+            playHistory.setUserId(rs.getLong("user_id"));
+            playHistory.setStreamingId(rs.getLong("streaming_id"));
+            playHistory.setLastPlayTime(rs.getInt("last_play_time"));
+            playHistory.setSourceIp(rs.getString("source_ip"));
+            playHistory.setCreatedAt(rs.getTimestamp("created_at").toLocalDateTime());
+            return playHistory;
+        });
+
+        return new SynchronizedItemStreamReaderBuilder<PlayHistory>()
+                .delegate(reader)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public ItemWriter<PlayHistory> redisWriter(
+            @Value("#{jobParameters[targetDate]}") String date
+    ) {
+
+        return items -> {
+            log.info("redisWriter 처리 시작");
+            Map<String, Map<String, Long>> batchUpdates = new HashMap<>();
+
+            // 1. 메모리에서 모든 데이터 집계
+            for (PlayHistory playHistory : items) {
+                String key = REDIS_KEY_PREFIX + date + ":" + playHistory.getStreamingId();
+                batchUpdates.computeIfAbsent(key, k -> new HashMap<>() {{
+                    put("playTime", 0L);
+                    put("adViews", 0L);
+                    put("streamingViews", 0L);
+                }});
+
+                Map<String, Long> values = batchUpdates.get(key);
+                values.put("playTime", values.get("playTime") + playHistory.getLastPlayTime());
+                values.put("adViews", values.get("adViews") + (playHistory.getLastPlayTime() / AD_INTERVAL_MINUTES));
+                values.put("streamingViews", values.get("streamingViews") + 1);
+            }
+
+            // 2. Redis Pipeline 사용하여 한번에 업데이트
+            redisTemplate.execute((RedisCallback<Object>) connection -> {
+                StringRedisConnection stringRedisConn = (StringRedisConnection) connection;
+                batchUpdates.forEach((key, values) -> {
+                    stringRedisConn.hIncrBy(key, "playTime", values.get("playTime"));
+                    stringRedisConn.hIncrBy(key, "adViews", values.get("adViews"));
+                    stringRedisConn.hIncrBy(key, "streamingViews", values.get("streamingViews"));
+                    stringRedisConn.expire(key, Duration.ofDays(1).toSeconds());
+                });
+                return null;
+            });
+        };
+    }
+}

--- a/src/main/java/streamingsettlement/batch/step/v3/RedisToDailyStatisticStepV3.java
+++ b/src/main/java/streamingsettlement/batch/step/v3/RedisToDailyStatisticStepV3.java
@@ -1,0 +1,141 @@
+package streamingsettlement.batch.step.v3;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.JdbcCursorItemReader;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.batch.item.support.SynchronizedItemStreamReader;
+import org.springframework.batch.item.support.builder.SynchronizedItemStreamReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import streamingsettlement.adjustment.domain.entity.DailyStatistic;
+import streamingsettlement.streaming.domain.entity.PlayHistory;
+import streamingsettlement.streaming.domain.entity.Streaming;
+
+import javax.sql.DataSource;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/**
+ * 병렬 처리 : 멀티 스레드
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisToDailyStatisticStepV3 {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String REDIS_KEY_PREFIX = "daily_stats:";
+    private final DataSource dataSource;
+
+    @Bean
+    @StepScope
+    public SynchronizedItemStreamReader<Streaming> streamingReader() {
+
+        JdbcCursorItemReader<Streaming> reader = new JdbcCursorItemReader<>();
+        reader.setDataSource(dataSource);
+        reader.setSql("SELECT id,streaming_views FROM streaming");
+        reader.setRowMapper((rs, rowNum) -> Streaming.builder()
+                .id(rs.getLong("id"))
+                .streamingViews(rs.getLong("streaming_views"))
+                .build());
+        return new SynchronizedItemStreamReaderBuilder<Streaming>()
+                .delegate(reader)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public ItemProcessor<Streaming, DailyStatistic> dailyStatisticProcessor(
+            @Value("#{jobParameters[targetDate]}") String date
+    ) {
+
+        return streaming -> {
+            String key = REDIS_KEY_PREFIX + date + ":" + streaming.getId();
+            HashOperations<String, String, String> hashOps = redisTemplate.opsForHash();
+
+            // Redis에서 데이터 조회, 없으면 0으로 처리
+            Long playTime = Long.parseLong(hashOps.get(key, "playTime") != null ?
+                    Objects.requireNonNull(hashOps.get(key, "playTime")) : "0");
+            Long adViews = Long.parseLong(hashOps.get(key, "adViews") != null ?
+                    Objects.requireNonNull(hashOps.get(key, "adViews")) : "0");
+            Long streamingViews = Long.parseLong(hashOps.get(key, "streamingViews") != null ?
+                    Objects.requireNonNull(hashOps.get(key, "streamingViews")) : "0");
+
+            // 정산금액 계산 로직 추가 필요
+            BigDecimal streamingUnitPrice = calculateStreamingUnitPrice(streaming.getStreamingViews());
+            BigDecimal adUnitPrice = calculateAdUnitPrice(streaming.getStreamingViews());
+
+            BigDecimal streamingAmount = streamingUnitPrice.multiply(BigDecimal.valueOf(streamingViews))
+                    .setScale(0, RoundingMode.DOWN);
+
+            BigDecimal advertisementAmount = adUnitPrice.multiply(BigDecimal.valueOf(adViews))
+                    .setScale(0, RoundingMode.DOWN);
+
+            return DailyStatistic.builder()
+                    .streamingId(streaming.getId())
+                    .streamingViews(streamingViews)
+                    .advertisementViews(adViews)
+                    .playTime(playTime)
+                    .streamingAmount(streamingAmount)
+                    .advertisementAmount(advertisementAmount)
+                    .statisticDate(LocalDate.parse(date).atStartOfDay())
+                    .createdAt(LocalDateTime.now())
+                    .build();
+        };
+    }
+
+    @Bean
+    public JdbcBatchItemWriter<DailyStatistic> dailyStatisticWriter() {
+        return new JdbcBatchItemWriterBuilder<DailyStatistic>()
+                .dataSource(dataSource)
+                .sql("""
+                        INSERT INTO daily_statistic (
+                            streaming_id,
+                            streaming_amount,
+                            advertisement_amount,
+                            streaming_views,
+                            advertisement_views,
+                            play_time,
+                            statistic_date,
+                            created_at
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                        """)
+                .itemPreparedStatementSetter((item, ps) -> {
+                    ps.setLong(1, item.getStreamingId());
+                    ps.setBigDecimal(2, item.getStreamingAmount());
+                    ps.setBigDecimal(3, item.getAdvertisementAmount());
+                    ps.setLong(4, item.getStreamingViews());
+                    ps.setLong(5, item.getAdvertisementViews());
+                    ps.setLong(6, item.getPlayTime());
+                    ps.setTimestamp(7, Timestamp.valueOf(item.getStatisticDate()));
+                    ps.setTimestamp(8, Timestamp.valueOf(item.getCreatedAt()));
+                })
+                .assertUpdates(false)
+                .build();
+    }
+
+    private BigDecimal calculateStreamingUnitPrice(long views) {
+        if (views >= 1_000_000) return BigDecimal.valueOf(1.5);
+        if (views >= 500_000) return BigDecimal.valueOf(1.3);
+        if (views >= 100_000) return BigDecimal.valueOf(1.1);
+        return BigDecimal.valueOf(1.0);
+    }
+
+    private BigDecimal calculateAdUnitPrice(long views) {
+        if (views >= 1_000_000) return BigDecimal.valueOf(20);
+        if (views >= 500_000) return BigDecimal.valueOf(15);
+        if (views >= 100_000) return BigDecimal.valueOf(12);
+        return BigDecimal.valueOf(10);
+    }
+}


### PR DESCRIPTION
- 스프링 배치 멀티 스레드를 통한 병렬 처리
- 기존 코드를 유지하며 thread-safe 하지 않은 JdbcCursorItemReader를 SynchronizedItemStreamReader 감싸 thread-safe하게 만들어 문제 해결